### PR TITLE
possible setup wizard fix?

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -4,6 +4,7 @@ rild.libpath=/system/lib/libril-icera.so
 rild.libargs=-e wwan0
 persist.tegra.nvmmlite = 1
 ro.audio.monitorOrientation=true
+net.tethering.noprovisioning=true
 
 #NFC
 debug.nfc.fw_download=false


### PR DESCRIPTION
i saw this on anddisa's device tree, and remember's people taking about the setup wizard crashing on xda, could this fix it, or is the fix only for AOSP?