### PR TITLE
Gabriele M's Disable HumanInteractionClassifier commit

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -286,4 +286,7 @@
 
     <!-- Flag indicating whether round icons should be parsed from the application manifest. -->
     <bool name="config_useRoundIcon">true</bool>
+     
+    <!-- Whether to enable HumanInteractionController by default -->
+    <bool name="config_HICEnabledDefault">false</bool>
 </resources>


### PR DESCRIPTION
HumaInteractionClassifier appears not to work properly on our
devices (at least some of them) and makes unlocking the screen
really hard at random, so disable it. The default option can
be still overridden running the following command:

  settings put global HIC_enable 1|0